### PR TITLE
feat/mifflin equation

### DIFF
--- a/app/src/bmr/helpers/coefficients.py
+++ b/app/src/bmr/helpers/coefficients.py
@@ -1,0 +1,11 @@
+
+coefficients = {'HarrisBenedict': {"male": {"imperial": {"weight": 6.24, "height": 12.7, "age": -6.75, "bias": 66.47}, 
+                                            "metric": {"weight": 13.75, "height": 5.003, "age": -6.75, "bias": 66.47}}, 
+                                    "female": {"imperial": {"weight": 4.34, "height": 4.7, "age": -4.676, "bias": 65.51}, 
+                                                "metric": {"weight": 9.563, "height": 1.850, "age": -4.676, "bias": 65.51}}},
+                'Mifflin': {"male": {"imperial": {"weight": 4.536, "height": 15.875, "age": -5, "bias": 5.0},
+                                     "metric": {"weight": 10.0, "height": 6.25, "age": -5, "bias": 5.0}}, 
+                            "female": {"imperial": {"weight": 4.536, "height": 15.875, "age": -5, "bias": -161},
+                                       "metric": {"weight": 10, "height": 6.25, "age": -5, "bias": -161}}}
+                } 
+                

--- a/app/src/bmr/helpers/coefficients.py
+++ b/app/src/bmr/helpers/coefficients.py
@@ -1,11 +1,29 @@
 
-coefficients = {'HarrisBenedict': {"male": {"imperial": {"weight": 6.24, "height": 12.7, "age": -6.75, "bias": 66.47}, 
-                                            "metric": {"weight": 13.75, "height": 5.003, "age": -6.75, "bias": 66.47}}, 
-                                    "female": {"imperial": {"weight": 4.34, "height": 4.7, "age": -4.676, "bias": 65.51}, 
-                                                "metric": {"weight": 9.563, "height": 1.850, "age": -4.676, "bias": 65.51}}},
-                'Mifflin': {"male": {"imperial": {"weight": 4.536, "height": 15.875, "age": -5, "bias": 5.0},
-                                     "metric": {"weight": 10.0, "height": 6.25, "age": -5, "bias": 5.0}}, 
-                            "female": {"imperial": {"weight": 4.536, "height": 15.875, "age": -5, "bias": -161},
-                                       "metric": {"weight": 10, "height": 6.25, "age": -5, "bias": -161}}}
-                } 
+coefficients = {
+        'HarrisBenedict': {"male": 
+                                {"imperial":
+                                        {"weight": 6.24, "height": 12.7, "age": -6.75, "bias": 66.47}, 
+                                "metric":
+                                        {"weight": 13.75, "height": 5.003, "age": -6.75, "bias": 66.47}}, 
+                        "female":
+                                {"imperial":
+                                        {"weight": 4.34, "height": 4.7, "age": -4.676, "bias": 65.51}, 
+                                "metric":
+                                        {"weight": 9.563, "height": 1.850, "age": -4.676, "bias": 65.51}
+                        }
+                },
+
+        'Mifflin': {"male": 
+                        {"imperial": 
+                                {"weight": 4.536, "height": 15.875, "age": -5, "bias": 5.0},
+                        "metric":
+                                {"weight": 10.0, "height": 6.25, "age": -5, "bias": 5.0}}, 
+                "female":
+                        {"imperial":
+                                {"weight": 4.536, "height": 15.875, "age": -5, "bias": -161},
+                        "metric":
+                                {"weight": 10, "height": 6.25, "age": -5, "bias": -161}
+                }
+        }
+} 
                 

--- a/app/src/bmr/helpers/equations.py
+++ b/app/src/bmr/helpers/equations.py
@@ -112,3 +112,141 @@ class HarrisBenedict:
             f"{self.weight_loss_rate}, {self.energy_deficit}, "
             f"{self.units})"
         )
+
+
+class Mifflin:
+    """Mifflin-St.Jeor bmr equation
+    This class will calculat the BMR using the Mifflin-St. Jeor
+    equation defined below:
+    for men:
+        metric
+        BMR = 10*weight[kg] + 6.25*height[cm] - 5*age[years] + 5
+        imperial
+        BMR = 4.536*weight[lbs] + 15.875*height[inches] − 5*age[years] + 5
+    for women:
+        metric
+        BMR = 10*weight[kg] + 6.25*height[cm] - 5*age[years] - 161
+        imperial
+        BMR = 4.536*weight[lbs] + 15.875*height[inches] − 5*age[years] − 161;
+    """
+
+    def __init__(
+        self,
+        age: int,
+        height: float,
+        weight: float,
+        time_projection: np.ndarray,
+        weight_loss_rate: float,
+        units: str = "imperial",
+        energy_deficit: float = 1000,
+    ) -> None:
+
+        assert 19 <= age <= 150, (
+            "Height stop chaning probalbly after 19"
+            "and normally people don't live more than "
+            "150 years!"
+        )
+        assert height >= 0, "Height must be positive"
+        assert time_projection.size != 0, (
+            "Time projection is required. "
+            "Calculate with the "
+            "time_projection module"
+        )
+        assert weight >= 0, "Initial weight must be positive"
+        assert energy_deficit >= 0, "Energy deficit must be positive"
+        assert units == "imperial" or units == "metric", (
+            "Units must be on " "imperial or metric" "system"
+        )
+
+        if units == "imperial":
+            self.height_unit = "inches"
+            self.weight_unit = "lbs"
+        else:
+            self.height_unit = "cm"
+            self.weight_unit = "kg"
+
+        self.age = age
+        self.height = height
+        self.time_projection = time_projection
+        self.weight = weight
+        self.energy_deficit = energy_deficit
+        self.units = units
+        self.weight_loss_rate = weight_loss_rate
+
+    def men_eq(self) -> tuple[np.ndarray, np.ndarray]:
+        if self.units == "imperial":
+            bmr = (
+                4.536
+                * (
+                    self.weight
+                    - (self.weight_loss_rate * self.time_projection)
+                )
+                + (15.875 * self.height)
+                - (5 * self.age)
+                + 5
+            )
+
+            bmr_deficit = bmr - self.energy_deficit
+            return bmr, bmr_deficit
+        else:
+            bmr = (
+                10
+                * (
+                    self.weight
+                    - (self.weight_loss_rate * self.time_projection)
+                )
+                + (6.25 * self.height)
+                - (5 * self.age)
+                + 5
+            )
+
+            bmr_deficit = bmr - self.energy_deficit
+            return bmr, bmr_deficit
+
+    def female_eq(self) -> tuple[np.ndarray, np.ndarray]:
+        if self.units == "imperial":
+            bmr = (
+                4.536
+                * (
+                    self.weight
+                    - (self.weight_loss_rate * self.time_projection)
+                )
+                + (15.875 * self.height)
+                - (5 * self.age)
+                - 161
+            )
+
+            bmr_deficit = bmr - self.energy_deficit
+            return bmr, bmr_deficit
+        else:
+            bmr = (
+                10
+                * (
+                    self.weight
+                    - (self.weight_loss_rate * self.time_projection)
+                )
+                + (6.25 * self.height)
+                - (5 * self.age)
+                - 161
+            )
+
+            bmr_deficit = bmr - self.energy_deficit
+            return bmr, bmr_deficit
+
+    def __str__(self) -> str:
+        return (
+            f"Mifflin-St. Jeor BMR equation for a {self.age}-years "
+            f"old person with {self.weight}-{self.weight_unit} weight and "
+            f"{self.height}-{self.height_unit} height. Projection over "
+            f"{self.time_projection}-weeks with a weight loss rate of "
+            f"{self.weight_loss_rate}-{self.weight_unit} per week and "
+            f"an energy deficit of {self.energy_deficit}-cals"
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"Mifflin-St. Jeor({self.age}, {self.height}, "
+            f"{self.weight}, {self.time_projection}, "
+            f"{self.weight_loss_rate}, {self.energy_deficit}, "
+            f"{self.units})"
+        )

--- a/app/src/bmr/helpers/equations.py
+++ b/app/src/bmr/helpers/equations.py
@@ -1,6 +1,5 @@
 import numpy as np
-from coefficients import coefficients
-
+from app.src.bmr.helpers.coefficients import coefficients
 
 class HarrisBenedict:
     def __init__(
@@ -9,6 +8,7 @@ class HarrisBenedict:
         height: float,
         weight: float,
         time_projection: np.ndarray,
+        sex: str,
         units: str = "imperial",
         weight_loss_rate: float = 2,
         energy_deficit: float = 1000,
@@ -45,56 +45,25 @@ class HarrisBenedict:
         self.weight_loss_rate = weight_loss_rate
         self.energy_deficit = energy_deficit
         self.units = units
+        self.sex = sex
 
-    def men_eq(self) -> tuple[np.ndarray, np.ndarray]:
-        if self.units == "imperial":
-            bmr = (
-                66.47
-                + 6.24
-                * (
-                    self.weight
-                    - (self.weight_loss_rate * self.time_projection)
-                )
-                + 12.7 * self.height
-                - 6.76 * self.age
-            )
-            bmr_deficit = bmr - self.energy_deficit
-            return bmr, bmr_deficit
-        else:
-            bmr = (
-                66.47
-                + 13.75
-                * (self.weight - self.weight_loss_rate * self.time_projection)
-                + 5.003 * self.height
-                - 6.75 * self.age
-            )
-            bmr_deficit = bmr - self.energy_deficit
-            return bmr, bmr_deficit
+        self.coefficients = coefficients['HarrisBenedict'][self.sex][self.units]
+        # make sure the coefficients are loaded
+        assert self.coefficients != None
 
-    def female_eq(self) -> tuple[np.ndarray, np.ndarray]:
-        if self.units == "imperial":
-            bmr = (
-                65.51
-                + 4.34
-                * (
-                    self.weight
-                    - (self.weight_loss_rate * self.time_projection)
-                )
-                + 4.7 * (self.height)
-                - 4.676 * (self.age)
+    def get_bmr(self) -> float:
+        bmr = (
+            (self.coefficients['weight'] * (self.weight - (self.weight_loss_rate * self.time_projection)))
+            + (self.coefficients['height'] * self.height)
+            + (self.coefficients['age'] * self.age)
+            + self.coefficients['bias']
             )
-            bmr_deficit = bmr - self.energy_deficit
-            return bmr, bmr_deficit
-        else:
-            bmr = (
-                65.1
-                + 9.563
-                * (self.weight - self.weight_loss_rate * self.time_projection)
-                + 1.850 * self.height
-                - 4.676 * self.age
-            )
-            bmr_deficit = bmr - self.energy_deficit
-            return bmr, bmr_deficit
+        return bmr
+    
+    def get_bmr_and_deficit(self) -> tuple[np.array, np.array]:
+        bmr = self.get_bmr()
+        bmr_deficit = bmr - self.energy_deficit
+        return bmr, bmr_deficit
 
     def __str__(self) -> str:
         return (
@@ -178,85 +147,25 @@ class Mifflin:
         self.units = units
         self.weight_loss_rate = weight_loss_rate
         self.sex = sex
-        self.coefficients = self._get_coefficients()
 
-    def _get_coefficients(self):
-        self.coefficients = coefficients[self.__name__][self.sex][self.units]
+        self.coefficients = coefficients['Mifflin'][self.sex][self.units]
+        # make sure the coefficients are loaded
+        assert self.coefficients != None
 
     def get_bmr(self) -> float:
         bmr = (
-            (self.coefficients['weight'] * self.weight)
+            (self.coefficients['weight'] * (self.weight - (self.weight_loss_rate * self.time_projection)))
             + (self.coefficients['height'] * self.height)
             + (self.coefficients['age'] * self.age)
             + self.coefficients['bias']
             )
         return bmr
     
-    def get_bmr_and_deficit(self) -> tuple[np.array, np.array]:
+    def get_bmr_and_deficit(self) -> tuple[np.ndarray, np.ndarray]:
         bmr = self.get_bmr()
         bmr_deficit = bmr - self.energy_deficit
         return bmr, bmr_deficit
     
-    def men_eq(self) -> tuple[np.ndarray, np.ndarray]:
-        if self.units == "imperial":
-            bmr = (
-                4.536
-                * (
-                    self.weight
-                    - (self.weight_loss_rate * self.time_projection)
-                )
-                + (15.875 * self.height)
-                - (5 * self.age)
-                + 5
-            )
-
-            bmr_deficit = bmr - self.energy_deficit
-            return bmr, bmr_deficit
-        else:
-            bmr = (
-                10
-                * (
-                    self.weight
-                    - (self.weight_loss_rate * self.time_projection)
-                )
-                + (6.25 * self.height)
-                - (5 * self.age)
-                + 5
-            )
-
-            bmr_deficit = bmr - self.energy_deficit
-            return bmr, bmr_deficit
-
-    def female_eq(self) -> tuple[np.ndarray, np.ndarray]:
-        if self.units == "imperial":
-            bmr = (
-                4.536
-                * (
-                    self.weight
-                    - (self.weight_loss_rate * self.time_projection)
-                )
-                + (15.875 * self.height)
-                - (5 * self.age)
-                - 161
-            )
-
-            bmr_deficit = bmr - self.energy_deficit
-            return bmr, bmr_deficit
-        else:
-            bmr = (
-                10
-                * (
-                    self.weight
-                    - (self.weight_loss_rate * self.time_projection)
-                )
-                + (6.25 * self.height)
-                - (5 * self.age)
-                - 161
-            )
-
-            bmr_deficit = bmr - self.energy_deficit
-            return bmr, bmr_deficit
-
     def __str__(self) -> str:
         return (
             f"Mifflin-St. Jeor BMR equation for a {self.age}-years "

--- a/app/src/bmr/helpers/equations.py
+++ b/app/src/bmr/helpers/equations.py
@@ -1,4 +1,5 @@
 import numpy as np
+from coefficients import coefficients
 
 
 class HarrisBenedict:
@@ -61,7 +62,7 @@ class HarrisBenedict:
             return bmr, bmr_deficit
         else:
             bmr = (
-                66.5
+                66.47
                 + 13.75
                 * (self.weight - self.weight_loss_rate * self.time_projection)
                 + 5.003 * self.height
@@ -80,13 +81,13 @@ class HarrisBenedict:
                     - (self.weight_loss_rate * self.time_projection)
                 )
                 + 4.7 * (self.height)
-                - 4.7 * (self.age)
+                - 4.676 * (self.age)
             )
             bmr_deficit = bmr - self.energy_deficit
             return bmr, bmr_deficit
         else:
             bmr = (
-                655.1
+                65.1
                 + 9.563
                 * (self.weight - self.weight_loss_rate * self.time_projection)
                 + 1.850 * self.height
@@ -136,6 +137,7 @@ class Mifflin:
         height: float,
         weight: float,
         time_projection: np.ndarray,
+        sex: str,
         units: str = "imperial",
         weight_loss_rate: float = 2,
         energy_deficit: float = 1000,
@@ -158,12 +160,15 @@ class Mifflin:
             "Units must be on " "imperial or metric" "system"
         )
 
+        assert sex in ['male', 'female'], ('Sex must be male or female')
+
         if units == "imperial":
             self.height_unit = "inches"
             self.weight_unit = "lbs"
         else:
             self.height_unit = "cm"
             self.weight_unit = "kg"
+        
 
         self.age = age
         self.height = height
@@ -172,7 +177,26 @@ class Mifflin:
         self.energy_deficit = energy_deficit
         self.units = units
         self.weight_loss_rate = weight_loss_rate
+        self.sex = sex
+        self.coefficients = self._get_coefficients()
 
+    def _get_coefficients(self):
+        self.coefficients = coefficients[self.__name__][self.sex][self.units]
+
+    def get_bmr(self) -> float:
+        bmr = (
+            (self.coefficients['weight'] * self.weight)
+            + (self.coefficients['height'] * self.height)
+            + (self.coefficients['age'] * self.age)
+            + self.coefficients['bias']
+            )
+        return bmr
+    
+    def get_bmr_and_deficit(self) -> tuple[np.array, np.array]:
+        bmr = self.get_bmr()
+        bmr_deficit = bmr - self.energy_deficit
+        return bmr, bmr_deficit
+    
     def men_eq(self) -> tuple[np.ndarray, np.ndarray]:
         if self.units == "imperial":
             bmr = (

--- a/app/src/bmr/helpers/equations.py
+++ b/app/src/bmr/helpers/equations.py
@@ -136,8 +136,8 @@ class Mifflin:
         height: float,
         weight: float,
         time_projection: np.ndarray,
-        weight_loss_rate: float,
         units: str = "imperial",
+        weight_loss_rate: float = 2,
         energy_deficit: float = 1000,
     ) -> None:
 

--- a/app/src/bmr/model.py
+++ b/app/src/bmr/model.py
@@ -2,7 +2,7 @@ import numpy as np
 from typing import TypeAlias
 from .helpers import time_projection as time_proj
 from .helpers import weight_projection as weight_proj
-from .helpers.equations import HarrisBenedict
+from .helpers.equations import HarrisBenedict, Mifflin
 
 JSONType: TypeAlias = dict[str, str | None]
 
@@ -22,10 +22,29 @@ class Builder:
         self.weight_proj = weight_proj.calculate(
             weight_initial=self.weight, time_projection=self.time_proj
         )
+        self.equations = {} # JD - new empty dictionary to hold equation objects
 
     def build(self) -> Exception | None:
+
+        # here, both equaations are stored in a dictionary so that either can be
+        # chosen downstream by using the equation keyword.
+        # valid kewords:
+        # "HarrisBenedict" - Haris Benedict equation
+        # "Mifflin" - Mifflin-St. Jeor equation
+        # 
+         
         try:
-            self.equations = HarrisBenedict(
+            self.equations["HarrisBenedict"] = HarrisBenedict(
+                age=self.age,
+                height=self.height,
+                weight=self.weight,
+                time_projection=self.time_proj,
+                units=self.units,
+                weight_loss_rate=self.weight_loss_rate,
+                energy_deficit=self.energy_deficit,
+            )
+
+            self.equations["Mifflin"] = Mifflin(
                 age=self.age,
                 height=self.height,
                 weight=self.weight,
@@ -37,11 +56,22 @@ class Builder:
         except Exception as e:
             return e
 
-    def calculate(self) -> None:
+    def calculate(self, equation='Mifflin') -> None:
+        '''
+        Perform BMR calculation with selected equation.
+        Defaults to HarrisBenedict equation.
+        '''
+
+        # Choice of equation must match implemented equation classes
+        assert equation in self.equations.keys(), (
+            f"Unknown equation: {equation}"
+            f"Valid equations: {self.equations.keys()}"
+        )
+        
         if self.sex == "men":
-            self.bmr, self.bmr_deficit = self.equations.men_eq()
+            self.bmr, self.bmr_deficit = self.equations[equation].men_eq()
         else:
-            self.bmr, self.bmr_deficit = self.equations.female_eq()
+            self.bmr, self.bmr_deficit = self.equations[equation].female_eq()
 
     def jasonable_dict(self) -> dict:
         return {

--- a/app/src/bmr/model.py
+++ b/app/src/bmr/model.py
@@ -1,8 +1,8 @@
 import numpy as np
 from typing import TypeAlias
-from .helpers import time_projection as time_proj
-from .helpers import weight_projection as weight_proj
-from .helpers.equations import HarrisBenedict, Mifflin
+from app.src.bmr.helpers import time_projection as time_proj
+from app.src.bmr.helpers import weight_projection as weight_proj
+from app.src.bmr.helpers.equations import HarrisBenedict, Mifflin
 
 JSONType: TypeAlias = dict[str, str | None]
 
@@ -39,6 +39,7 @@ class Builder:
                 height=self.height,
                 weight=self.weight,
                 time_projection=self.time_proj,
+                sex=self.sex,
                 units=self.units,
                 weight_loss_rate=self.weight_loss_rate,
                 energy_deficit=self.energy_deficit,
@@ -49,6 +50,7 @@ class Builder:
                 height=self.height,
                 weight=self.weight,
                 time_projection=self.time_proj,
+                sex=self.sex,
                 units=self.units,
                 weight_loss_rate=self.weight_loss_rate,
                 energy_deficit=self.energy_deficit,
@@ -68,10 +70,7 @@ class Builder:
             f"Valid equations: {self.equations.keys()}"
         )
         
-        if self.sex == "men":
-            self.bmr, self.bmr_deficit = self.equations[equation].men_eq()
-        else:
-            self.bmr, self.bmr_deficit = self.equations[equation].female_eq()
+        self.bmr, self.bmr_deficit = self.equations[equation].get_bmr_and_deficit()
 
     def jasonable_dict(self) -> dict:
         return {

--- a/app/src/bmr/model.py
+++ b/app/src/bmr/model.py
@@ -26,12 +26,12 @@ class Builder:
 
     def build(self) -> Exception | None:
 
-        # here, both equaations are stored in a dictionary so that either can be
+        # here, both equations are stored in a dictionary so that either can be
         # chosen downstream by using the equation keyword.
         # valid kewords:
-        # "HarrisBenedict" - Haris Benedict equation
-        # "Mifflin" - Mifflin-St. Jeor equation
-        # 
+        #       "HarrisBenedict" - Haris Benedict equation
+        #       "Mifflin" - Mifflin-St. Jeor equation
+    
          
         try:
             self.equations["HarrisBenedict"] = HarrisBenedict(

--- a/tests/test_harris_benedict_eqs.py
+++ b/tests/test_harris_benedict_eqs.py
@@ -12,10 +12,12 @@ class TestEquationsHarrisBenedict(unittest.TestCase):
         weight_initial = 10
         weight_loss_rate = 2
         energy_deficit = 0
+        sex = 'male'
         harris_benedict = HarrisBenedict(
             age=age,
             height=height,
             time_projection=time_projected,
+            sex=sex,
             weight=weight_initial,
             energy_deficit=energy_deficit,
         )
@@ -38,10 +40,12 @@ class TestEquationsHarrisBenedict(unittest.TestCase):
         units = "imperial"
         weight_loss_rate = 2
         energy_deficit = 0
+        sex='male'
         harris_benedict = HarrisBenedict(
             age=age,
             height=height,
             time_projection=time_projected,
+            sex=sex,
             units="imperial",
             weight=weight_initial,
             energy_deficit=energy_deficit,
@@ -62,11 +66,13 @@ class TestEquationsHarrisBenedict(unittest.TestCase):
         time_projected = np.array([1, 2, 3])
         weight_initial = 10
         energy_deficit = 0
+        sex='male'
         with pytest.raises(AssertionError):
             HarrisBenedict(
                 age=age,
                 height=height,
                 time_projection=time_projected,
+                sex=sex,
                 weight=weight_initial,
                 energy_deficit=energy_deficit,
             )
@@ -79,11 +85,13 @@ class TestEquationsHarrisBenedict(unittest.TestCase):
         time_projected = np.array([1, 2, 3])
         weight_initial = np.array([100, 98, 88])
         energy_deficit = 0
+        sex = 'male'
         with pytest.raises(AssertionError):
             HarrisBenedict(
                 age=age,
                 height=height,
                 time_projection=time_projected,
+                sex=sex,
                 weight=weight_initial,  # type: ignore
                 energy_deficit=energy_deficit,
             )
@@ -96,11 +104,13 @@ class TestEquationsHarrisBenedict(unittest.TestCase):
         time_projected = np.array([])
         weight_initial = np.array([100, 98, 88])
         energy_deficit = 0
+        sex = 'male'
         with pytest.raises(AssertionError):
             HarrisBenedict(
                 age=age,
                 height=height,
                 time_projection=time_projected,
+                sex=sex,
                 weight=weight_initial,  # type: ignore
                 energy_deficit=energy_deficit,
             )
@@ -113,11 +123,13 @@ class TestEquationsHarrisBenedict(unittest.TestCase):
         time_projected = np.array([1, 2, 3])
         weight_initial = -1
         energy_deficit = 0
+        sex = 'male'
         with pytest.raises(AssertionError):
             HarrisBenedict(
                 age=age,
                 height=height,
                 time_projection=time_projected,
+                sex=sex,
                 weight=weight_initial,
                 energy_deficit=energy_deficit,
             )
@@ -130,33 +142,38 @@ class TestEquationsHarrisBenedict(unittest.TestCase):
         time_projected = np.array([1, 2, 3])
         weight_initial = 10
         energy_deficit = -10
+        sex = 'male'
         with pytest.raises(AssertionError):
             HarrisBenedict(
                 age=age,
                 height=height,
                 time_projection=time_projected,
+                sex=sex,
                 weight=weight_initial,
                 energy_deficit=energy_deficit,
             )
 
-    def test_men_eq_in_pounds_return_valid_result(self) -> None:
+    def test_male_imperial_return_valid_result(self) -> None:
         age = 33
         height = 71
         weight_initial = 196
         time_projected = np.array([0])
+        sex = 'male'
         harris_benedict = HarrisBenedict(
             age=age,
             height=height,
             weight=weight_initial,
             time_projection=time_projected,
+            sex=sex
         )
         bmr_expected, bmr_deficit_expected = (
-            np.array([1968.13]),
-            np.array([968.13]),
+            np.array([1968.46]),
+            np.array([968.46])
         )
         (bmr_actual, bmr_deficit_actual) = np.round(
-            harris_benedict.men_eq(), 2
+            harris_benedict.get_bmr_and_deficit(), 2
         )
+
         for i in range(0, len(bmr_expected)):
             self.assertEqual(bmr_expected[i], bmr_actual[i])
             self.assertEqual(bmr_deficit_expected[i], bmr_deficit_actual[i])

--- a/tests/test_mifflin_eqs.py
+++ b/tests/test_mifflin_eqs.py
@@ -1,0 +1,294 @@
+import unittest
+import pytest
+import numpy as np
+from app.src.bmr.helpers.equations import Mifflin
+
+
+class TestEquationsMifflin(unittest.TestCase):
+
+###############################################################################
+##                    Override method tests                                  ##
+###############################################################################
+
+    def test_equations_mifflin_str(self) -> None:
+        age = 22
+        height = 5.5
+        time_projected = np.array([1, 2, 3])
+        weight_initial = 10
+        weight_loss_rate = 2
+        energy_deficit = 0
+        mifflin = Mifflin(
+            age=age,
+            height=height,
+            weight=weight_initial,
+            time_projection=time_projected,
+            weight_loss_rate=weight_loss_rate,
+            energy_deficit=energy_deficit
+        )
+        str_expected = (
+            f"Mifflin-St. Jeor BMR equation for a {age}-years "
+            f"old person with {weight_initial}-lbs weight and "
+            f"{height}-inches height. Projection over "
+            f"{time_projected}-weeks with a weight loss rate of "
+            f"{weight_loss_rate}-lbs per week and an energy "
+            f"deficit of {energy_deficit}-cals"
+        )
+        str_actual = str(mifflin)
+        self.assertEqual(str_expected, str_actual)
+
+    def test_equations_mifflin_repr(self) -> None:
+        age = 22
+        height = 5.5
+        weight_initial = 10
+        time_projected = np.array([1, 2, 3])
+        units = "imperial"
+        weight_loss_rate = 2
+        energy_deficit = 0
+        mifflin = Mifflin(
+            age=age,
+            height=height,
+            weight=weight_initial,
+            time_projection=time_projected,
+            weight_loss_rate=weight_loss_rate,
+            energy_deficit=energy_deficit
+        )
+        repr_expected = (
+            f"Mifflin-St. Jeor({age}, {height}, {weight_initial}, "
+            f"{time_projected}, {weight_loss_rate}, "
+            f"{energy_deficit}, {units})"
+        )
+        repr_actual = repr(mifflin)
+        self.assertEqual(repr_expected, repr_actual)
+
+###############################################################################
+##                    Input validation tests                                 ##
+###############################################################################
+
+    def test_equations_mifflin_raises_assertion_age_less_19(
+        self,
+    ) -> None:
+        age = 5
+        height = 5.5
+        time_projected = np.array([1, 2, 3])
+        weight_initial = 10
+        energy_deficit = 0
+        weight_loss_rate = 0.5
+        units = 'metric'
+        with pytest.raises(AssertionError):
+            Mifflin(
+                age=age,
+                height=height,
+                weight=weight_initial,
+                time_projection=time_projected,
+                weight_loss_rate=weight_loss_rate,
+                energy_deficit=energy_deficit
+            )
+
+    def test_equations_miffflin_raises_assertion_height_less_0(
+        self,
+    ) -> None:
+        age = 22
+        height = -10
+        time_projected = np.array([1, 2, 3])
+        weight_initial = np.array([100, 98, 88])
+        energy_deficit = 0
+        weight_loss_rate = 2
+        with pytest.raises(AssertionError):
+            Mifflin(
+                age=age,
+                height=height,
+                time_projection=time_projected,
+                weight=weight_initial,  # type: ignore
+                weight_loss_rate=weight_loss_rate,
+                energy_deficit=energy_deficit
+            )
+
+    def test_equations_mifflin_raises_assertion_time_empty(
+        self,
+    ) -> None:
+        age = 22
+        height = 5.5
+        time_projected = np.array([])
+        weight_initial = np.array([100, 98, 88])
+        energy_deficit = 0
+        weight_loss_rate = 0.5
+        with pytest.raises(AssertionError):
+            Mifflin(
+                age=age,
+                height=height,
+                time_projection=time_projected,
+                weight=weight_initial,  # type: ignore
+                weight_loss_rate=weight_loss_rate,
+                energy_deficit=energy_deficit
+            )
+
+    def test_equations_mifflin_raises_assertion_weight_negative(
+        self,
+    ) -> None:
+        age = 22
+        height = 5.5
+        time_projected = np.array([1, 2, 3])
+        weight_initial = -1
+        energy_deficit = 0
+        weight_loss_rate = 0.2
+        with pytest.raises(AssertionError):
+            Mifflin(
+                age=age,
+                height=height,
+                time_projection=time_projected,
+                weight=weight_initial,
+                weight_loss_rate=weight_loss_rate,
+                energy_deficit=energy_deficit
+            )
+
+    def test_equations_mifflin_raises_assertion_energy_deficit_negative(
+        self,
+    ) -> None:
+        age = 22
+        height = 5.5
+        time_projected = np.array([1, 2, 3])
+        weight_initial = 10
+        energy_deficit = -10
+        weight_loss_rate = 0.5
+        with pytest.raises(AssertionError):
+                Mifflin(
+                    age=age,
+                    height=height,
+                    time_projection=time_projected,
+                    weight=weight_initial,
+                    weight_loss_rate=weight_loss_rate,
+                    energy_deficit=energy_deficit
+                    )
+
+###############################################################################
+##                   Correct calculation tests                               ##
+##                                                                           ##
+## For both men and women the following vallus will be tested:               ##
+## Imperial:                                                                 ##
+##       initial weight = 196 lb
+##       height = 71 in
+##       age = 33 yrs
+##       energy deficit = 1000
+##       time projection = 0
+##       weight loss rate = 2
+## 
+## Metric:                                                                 ##
+##       initial weight = 88.9 kg
+##       height = 180.34 cm
+##       age = 33 yrs
+##       energy deficit = 1000
+##       time projection = 0
+##       weight loss rate = 0.5
+###############################################################################
+
+    def test_men_eq_imperial_return_valid_result(self) -> None:
+        age = 33
+        height = 71
+        weight_initial = 196
+        time_projected = np.array([0])
+        weight_loss_rate = 2
+        units = 'imperial'
+        mifflin = Mifflin(
+            age=age,
+            height=height,
+            weight=weight_initial,
+            time_projection=time_projected,
+            weight_loss_rate=weight_loss_rate,
+            units=units
+
+        )
+        bmr_expected, bmr_deficit_expected = (
+            np.array([1856.18]),
+            np.array([856.18]),
+        )
+        (bmr_actual, bmr_deficit_actual) = np.round(
+            mifflin.men_eq(), 2
+        )
+        for i in range(0, len(bmr_expected)):
+            self.assertEqual(bmr_expected[i], bmr_actual[i])
+            self.assertEqual(bmr_deficit_expected[i], bmr_deficit_actual[i])    
+
+    def test_men_eq_metric_return_valid_result(self) -> None:
+        age = 33
+        height = 180.34
+        weight_initial = 88.9
+        time_projected = np.array([0])
+        weight_loss_rate = 0.5
+        units = 'metric'
+        mifflin = Mifflin(
+            age=age,
+            height=height,
+            weight=weight_initial,
+            time_projection=time_projected,
+            weight_loss_rate=weight_loss_rate,
+            units = units
+
+        )
+        bmr_expected, bmr_deficit_expected = (
+            np.array([1856.12]),
+            np.array([856.12]),
+        )
+        (bmr_actual, bmr_deficit_actual) = np.round(
+            mifflin.men_eq(), 2
+        )
+        for i in range(0, len(bmr_expected)):
+            self.assertEqual(bmr_expected[i], bmr_actual[i])
+            self.assertEqual(bmr_deficit_expected[i], bmr_deficit_actual[i])
+
+
+    def test_women_eq_imperial_return_valid_result(self) -> None:
+        age = 33
+        height = 71
+        weight_initial = 196
+        time_projected = np.array([0])
+        weight_loss_rate = 2
+        units = 'imperial'
+        mifflin = Mifflin(
+                age=age,
+                height=height,
+                weight=weight_initial,
+                time_projection=time_projected,
+                weight_loss_rate=weight_loss_rate,
+                units=units
+
+        )
+        bmr_expected, bmr_deficit_expected = (
+            np.array([1690.18]),
+            np.array([690.18]),
+        )
+
+        (bmr_actual, bmr_deficit_actual) = np.round(
+            mifflin.female_eq(), 2
+        )
+        for i in range(0, len(bmr_expected)):
+            self.assertEqual(bmr_expected[i], bmr_actual[i])
+            self.assertEqual(bmr_deficit_expected[i], bmr_deficit_actual[i])    
+
+    def test_women_eq_metric_return_valid_result(self) -> None:
+        age = 33
+        height = 180.34
+        weight_initial = 88.9
+        time_projected = np.array([0])
+        weight_loss_rate = 0.5
+        units = 'metric'
+        mifflin = Mifflin(
+                age=age,
+                height=height,
+                weight=weight_initial,
+                time_projection=time_projected,
+                weight_loss_rate=weight_loss_rate,
+                units=units
+
+        )
+        bmr_expected, bmr_deficit_expected = (
+            np.array([1690.12]),
+            np.array([690.12]),
+        )
+        (bmr_actual, bmr_deficit_actual) = np.round(
+            mifflin.female_eq(), 2
+        )
+        for i in range(0, len(bmr_expected)):
+            self.assertEqual(bmr_expected[i], bmr_actual[i])
+            self.assertEqual(bmr_deficit_expected[i], bmr_deficit_actual[i])
+
+

--- a/tests/test_mifflin_eqs.py
+++ b/tests/test_mifflin_eqs.py
@@ -17,11 +17,13 @@ class TestEquationsMifflin(unittest.TestCase):
         weight_initial = 10
         weight_loss_rate = 2
         energy_deficit = 0
+        sex = 'male'
         mifflin = Mifflin(
             age=age,
             height=height,
             weight=weight_initial,
             time_projection=time_projected,
+            sex=sex,
             weight_loss_rate=weight_loss_rate,
             energy_deficit=energy_deficit
         )
@@ -44,11 +46,13 @@ class TestEquationsMifflin(unittest.TestCase):
         units = "imperial"
         weight_loss_rate = 2
         energy_deficit = 0
+        sex = 'male'
         mifflin = Mifflin(
             age=age,
             height=height,
             weight=weight_initial,
             time_projection=time_projected,
+            sex=sex,
             weight_loss_rate=weight_loss_rate,
             energy_deficit=energy_deficit
         )
@@ -73,6 +77,7 @@ class TestEquationsMifflin(unittest.TestCase):
         weight_initial = 10
         energy_deficit = 0
         weight_loss_rate = 0.5
+        sex = 'male'
         units = 'metric'
         with pytest.raises(AssertionError):
             Mifflin(
@@ -80,6 +85,7 @@ class TestEquationsMifflin(unittest.TestCase):
                 height=height,
                 weight=weight_initial,
                 time_projection=time_projected,
+                sex=sex,
                 weight_loss_rate=weight_loss_rate,
                 energy_deficit=energy_deficit
             )
@@ -93,11 +99,13 @@ class TestEquationsMifflin(unittest.TestCase):
         weight_initial = np.array([100, 98, 88])
         energy_deficit = 0
         weight_loss_rate = 2
+        sex = 'male'
         with pytest.raises(AssertionError):
             Mifflin(
                 age=age,
                 height=height,
                 time_projection=time_projected,
+                sex=sex,
                 weight=weight_initial,  # type: ignore
                 weight_loss_rate=weight_loss_rate,
                 energy_deficit=energy_deficit
@@ -112,11 +120,13 @@ class TestEquationsMifflin(unittest.TestCase):
         weight_initial = np.array([100, 98, 88])
         energy_deficit = 0
         weight_loss_rate = 0.5
+        sex = 'male'
         with pytest.raises(AssertionError):
             Mifflin(
                 age=age,
                 height=height,
                 time_projection=time_projected,
+                sex=sex,
                 weight=weight_initial,  # type: ignore
                 weight_loss_rate=weight_loss_rate,
                 energy_deficit=energy_deficit
@@ -131,11 +141,13 @@ class TestEquationsMifflin(unittest.TestCase):
         weight_initial = -1
         energy_deficit = 0
         weight_loss_rate = 0.2
+        sex = 'male'
         with pytest.raises(AssertionError):
             Mifflin(
                 age=age,
                 height=height,
                 time_projection=time_projected,
+                sex=sex,
                 weight=weight_initial,
                 weight_loss_rate=weight_loss_rate,
                 energy_deficit=energy_deficit
@@ -150,11 +162,55 @@ class TestEquationsMifflin(unittest.TestCase):
         weight_initial = 10
         energy_deficit = -10
         weight_loss_rate = 0.5
+        sex = 'male'
         with pytest.raises(AssertionError):
                 Mifflin(
                     age=age,
                     height=height,
                     time_projection=time_projected,
+                    sex=sex,
+                    weight=weight_initial,
+                    weight_loss_rate=weight_loss_rate,
+                    energy_deficit=energy_deficit
+                    )
+    
+    def test_equations_mifflin_raises_assertion_sex_invalid(
+        self,
+    ) -> None:
+        age = 22
+        height = 5.5
+        time_projected = np.array([1, 2, 3])
+        weight_initial = 10
+        energy_deficit = -10
+        weight_loss_rate = 0.5
+        sex = 'apple' # non mae or female valuess for sex
+        with pytest.raises(AssertionError):
+                Mifflin(
+                    age=age,
+                    height=height,
+                    time_projection=time_projected,
+                    sex=sex,
+                    weight=weight_initial,
+                    weight_loss_rate=weight_loss_rate,
+                    energy_deficit=energy_deficit
+                    )
+                
+    def test_equations_mifflin_raises_assertion_sex_empty(
+        self,
+    ) -> None:
+        age = 22
+        height = 5.5
+        time_projected = np.array([1, 2, 3])
+        weight_initial = 10
+        energy_deficit = -10
+        weight_loss_rate = 0.5
+        sex = ''
+        with pytest.raises(AssertionError):
+                Mifflin(
+                    age=age,
+                    height=height,
+                    time_projection=time_projected,
+                    sex=sex,
                     weight=weight_initial,
                     weight_loss_rate=weight_loss_rate,
                     energy_deficit=energy_deficit
@@ -188,11 +244,13 @@ class TestEquationsMifflin(unittest.TestCase):
         time_projected = np.array([0])
         weight_loss_rate = 2
         units = 'imperial'
+        sex = 'male'
         mifflin = Mifflin(
             age=age,
             height=height,
             weight=weight_initial,
             time_projection=time_projected,
+            sex=sex,
             weight_loss_rate=weight_loss_rate,
             units=units
 
@@ -202,7 +260,7 @@ class TestEquationsMifflin(unittest.TestCase):
             np.array([856.18]),
         )
         (bmr_actual, bmr_deficit_actual) = np.round(
-            mifflin.men_eq(), 2
+            mifflin.get_bmr_and_deficit(), 2
         )
         for i in range(0, len(bmr_expected)):
             self.assertEqual(bmr_expected[i], bmr_actual[i])
@@ -215,11 +273,13 @@ class TestEquationsMifflin(unittest.TestCase):
         time_projected = np.array([0])
         weight_loss_rate = 0.5
         units = 'metric'
+        sex = 'male'
         mifflin = Mifflin(
             age=age,
             height=height,
             weight=weight_initial,
             time_projection=time_projected,
+            sex=sex,
             weight_loss_rate=weight_loss_rate,
             units = units
 
@@ -229,7 +289,7 @@ class TestEquationsMifflin(unittest.TestCase):
             np.array([856.12]),
         )
         (bmr_actual, bmr_deficit_actual) = np.round(
-            mifflin.men_eq(), 2
+            mifflin.get_bmr_and_deficit(), 2
         )
         for i in range(0, len(bmr_expected)):
             self.assertEqual(bmr_expected[i], bmr_actual[i])
@@ -243,11 +303,13 @@ class TestEquationsMifflin(unittest.TestCase):
         time_projected = np.array([0])
         weight_loss_rate = 2
         units = 'imperial'
+        sex = 'female'
         mifflin = Mifflin(
                 age=age,
                 height=height,
                 weight=weight_initial,
                 time_projection=time_projected,
+                sex=sex,
                 weight_loss_rate=weight_loss_rate,
                 units=units
 
@@ -258,7 +320,7 @@ class TestEquationsMifflin(unittest.TestCase):
         )
 
         (bmr_actual, bmr_deficit_actual) = np.round(
-            mifflin.female_eq(), 2
+            mifflin.get_bmr_and_deficit(), 2
         )
         for i in range(0, len(bmr_expected)):
             self.assertEqual(bmr_expected[i], bmr_actual[i])
@@ -271,11 +333,13 @@ class TestEquationsMifflin(unittest.TestCase):
         time_projected = np.array([0])
         weight_loss_rate = 0.5
         units = 'metric'
+        sex = 'female'
         mifflin = Mifflin(
                 age=age,
                 height=height,
                 weight=weight_initial,
                 time_projection=time_projected,
+                sex=sex,
                 weight_loss_rate=weight_loss_rate,
                 units=units
 
@@ -285,7 +349,7 @@ class TestEquationsMifflin(unittest.TestCase):
             np.array([690.12]),
         )
         (bmr_actual, bmr_deficit_actual) = np.round(
-            mifflin.female_eq(), 2
+            mifflin.get_bmr_and_deficit(), 2
         )
         for i in range(0, len(bmr_expected)):
             self.assertEqual(bmr_expected[i], bmr_actual[i])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,9 +1,8 @@
 import unittest
 from app.src.bmr import model
 
-
 class TestModel(unittest.TestCase):
-    def test_model_return_dict(self) -> None:
+    def test_model_mifflin_return_dict(self) -> None:
         data = {
             "age": 33,
             "height": 71,
@@ -17,12 +16,12 @@ class TestModel(unittest.TestCase):
 
         bmr_model = model.Builder(data=data)
         bmr_model.build()
-        bmr_model.calculate()
+        bmr_model.calculate(equation='Mifflin')
 
         results_expected = {
             "age": 33,
-            "bmr": [1968],
-            "bmr_deficit": [968],
+            "bmr": [1856.0],
+            "bmr_deficit": [856.0],
             "energy_deficit": 1000,
             "height": 71,
             "sex": "men",
@@ -37,3 +36,49 @@ class TestModel(unittest.TestCase):
         results_actual = bmr_model.jasonable_dict()
 
         self.assertEqual(results_expected, results_actual)
+
+    def test_model_harris_return_dict(self) -> None:
+        data = {
+            "age": 33,
+            "height": 71,
+            "weight": 196,
+            "weeks": 0,
+            "units": "imperial",
+            "weight_loss_rate": 2,
+            "energy_deficit": 1000,
+            "sex": "men",
+        }
+
+        bmr_model = model.Builder(data=data)
+        bmr_model.build()
+        bmr_model.calculate(equation='HarrisBenedict')
+
+        results_expected = {
+            "age": 33,
+            "bmr": [1856.0],
+            "bmr_deficit": [856.0],
+            "energy_deficit": 1000,
+            "height": 71,
+            "sex": "men",
+            "time_projected": [0],
+            "units": "imperial",
+            "weeks": 0,
+            "weight": 196,
+            "weight_loss_rate": 2,
+            "weight_proj": [196],
+        }
+
+        results_actual = bmr_model.jasonable_dict()
+
+        self.assertEqual(results_expected, results_actual)
+
+
+  
+
+
+
+  
+
+
+
+

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -11,7 +11,7 @@ class TestModel(unittest.TestCase):
             "units": "imperial",
             "weight_loss_rate": 2,
             "energy_deficit": 1000,
-            "sex": "men",
+            "sex": "male",
         }
 
         bmr_model = model.Builder(data=data)
@@ -24,7 +24,7 @@ class TestModel(unittest.TestCase):
             "bmr_deficit": [856.0],
             "energy_deficit": 1000,
             "height": 71,
-            "sex": "men",
+            "sex": "male",
             "time_projected": [0],
             "units": "imperial",
             "weeks": 0,
@@ -46,7 +46,7 @@ class TestModel(unittest.TestCase):
             "units": "imperial",
             "weight_loss_rate": 2,
             "energy_deficit": 1000,
-            "sex": "men",
+            "sex": "male",
         }
 
         bmr_model = model.Builder(data=data)
@@ -55,11 +55,11 @@ class TestModel(unittest.TestCase):
 
         results_expected = {
             "age": 33,
-            "bmr": [1856.0],
-            "bmr_deficit": [856.0],
+            "bmr": [1968.0],
+            "bmr_deficit": [968.0],
             "energy_deficit": 1000,
             "height": 71,
-            "sex": "men",
+            "sex": "male",
             "time_projected": [0],
             "units": "imperial",
             "weeks": 0,


### PR DESCRIPTION
# Story Title

[Story: Perform Calculations on Input Data](https://github.com/yifattih/bmr_calculator/issues/19)

## Changes made

- Created app/src/bmr/helpers/coefficients.py, which stores equation coefficients for HarrisBenedict and Mifflin-St. Jeor equations
- Added Mifflin class that uses Mifflin-St. Jeor equation to app/src/bmr/helpers/equations.py
- Created tests for Mifflin class, main.py, and modified tests for Haarris-Benedict.
- The default equation in app/src/bmr/model.py is now Mifflin-St. Jeor
- Added sex parameter to both HarrisBenedict and Mifflin classes. Values can be 'male' or 'female'


## How does the solution address the problem

This PR enables backend use of either Mifflin-St. Jeor or Harris-Benedict equations to calculate BMR.

## Linked issues

Resolves #28 
Resolves #29 
Resolves #30 
Resolves #31 
Resolves #32 
