### PR TITLE
chore(docker/service): optimize service dockerfile with multi-stage build and alpine base images to improve security and reduce final image size

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,9 +1,8 @@
 # Stage 1: Build Dependencies
-FROM python:3.11-slim AS builder
+FROM python:3.11-alpine AS builder
 
 # Install necessary dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache gcc musl-dev libffi-dev make
 
 # Set the working directory for dependency installation
 WORKDIR /service
@@ -15,11 +14,11 @@ COPY requirements.txt /service/
 RUN pip install --user --no-cache-dir -r requirements.txt
 
 # Stage 2: Final Runtime Image
-FROM python:3.11-slim
+FROM python:3.11-alpine
 
 # Create a group and user (with error handling if already exists)
-RUN groupadd -f -r yifattih \
-    && useradd -r -g yifattih -m -d /home/yifattih -s /bin/bash yifattih
+RUN addgroup -S yifattih \
+    && adduser -S yifattih -G yifattih -h /home/yifattih
 
 # Set the working directory
 WORKDIR /service

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,40 +1,50 @@
-# app/Dockerfile
-FROM python:3.11-slim
+# Stage 1: Build Dependencies
+FROM python:3.11-slim AS builder
 
-# Install updates
-# Create a group
-# Create a user (with error handling if already exists)
-RUN apt-get autoremove \
-    && groupadd -f -r yifattih \
-    && useradd -r -g yifattih -m -d /home/yifattih -s /bin/bash yifattih
+# Install necessary dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
 
-# Set the working directory for the app
+# Set the working directory for dependency installation
 WORKDIR /service
 
-# Set ownership permissions to working directory
+# Copy requirements file
+COPY requirements.txt /service/
+
+# Install dependencies in a temporary directory
+RUN pip install --user --no-cache-dir -r requirements.txt
+
+# Stage 2: Final Runtime Image
+FROM python:3.11-slim
+
+# Create a group and user (with error handling if already exists)
+RUN groupadd -f -r yifattih \
+    && useradd -r -g yifattih -m -d /home/yifattih -s /bin/bash yifattih
+
+# Set the working directory
+WORKDIR /service
+
+# Set ownership permissions
 RUN chown -R yifattih:yifattih /service
 
 # Change user
 USER yifattih 
 
-# Copy app-specific requirements
-COPY requirements.txt /service/
-COPY Procfile /service/
-
-# Update pip and and install requirements
-RUN  pip install --user --upgrade pip \
-    && pip install --user --no-cache-dir -r requirements.txt
+# Copy installed dependencies from builder stage
+COPY --from=builder /root/.local /home/yifattih/.local
 
 # Add the user's local bin directory to PATH
 ENV PATH="/home/yifattih/.local/bin:$PATH"
 
+# Copy only necessary application files
+COPY --chown=yifattih:yifattih src/ /service/src/
+COPY --chown=yifattih:yifattih Procfile /service/
+
 # Add variable for Procfile execution via honcho
 ENV ENV="prod"
 
-# Copy the app code into the container
-COPY src/ /service/src/
-
+# Expose the application port
 EXPOSE 8000
 
-# Copy the app code into the container
+# Start the application
 CMD ["honcho", "start"]

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /service
 RUN chown -R yifattih:yifattih /service
 
 # Change user
-USER yifattih 
+USER yifattih  
 
 # Copy installed dependencies from builder stage
 COPY --from=builder /root/.local /home/yifattih/.local
@@ -36,8 +36,8 @@ COPY --from=builder /root/.local /home/yifattih/.local
 ENV PATH="/home/yifattih/.local/bin:$PATH"
 
 # Copy only necessary application files
-COPY --chown=yifattih:yifattih src/ /service/src/
-COPY --chown=yifattih:yifattih Procfile /service/
+COPY src/ /service/src/
+COPY Procfile /service/
 
 # Add variable for Procfile execution via honcho
 ENV ENV="prod"

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -1,6 +1,3 @@
-# Pin dependancies that might cause breakage
-Werkzeug==3.1.3
-
 # Data manipulation dependencies
 numpy==2.2.2
 


### PR DESCRIPTION
## Description
The current Dockerfile installs dependencies and copies application code in a single stage, leading to a larger image size. This PR will integrate a build stage where dependencies are installed first and a final stage where only the necessary dependencies are copied. Furthermore, it will switch the base image to reduce final image size.

## Changes made
- Split build into two stages
- Switched base image from python:3.11-slim to python:3.11-alpine
- Added build stage using alpine base image to install project dependencies
- Updated final stage to build with necessary files only
- Removed unnecessary python dependencies

## Linked issues
Resolves #68